### PR TITLE
feat: promote npm edge tag to latest when prerelease is promoted

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,32 @@ on:
   release:
     types:
       - published
-
+      - released
 jobs:
+  # When a prerelease is promoted to a full release, update the npm latest tag
+  promote:
+    if: github.event.action == 'released'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Install node 20
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          registry-url: https://registry.npmjs.org
+      - name: Promote edge to latest
+        run: |
+          VERSION=$(echo "$TAG_NAME" | sed 's/^v//')
+          PACKAGE=$(node -p "require('./package.json').name")
+          npm dist-tag add "$PACKAGE@$VERSION" latest
+          echo "::notice title=Promoted $VERSION to latest::The latest tag now points to $VERSION (was edge-only)"
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_DEPLOY_TOKEN}}
+
   deploy:
+    if: github.event.action == 'published'
     runs-on: ${{ matrix.os }}
     env:
       TERM: xterm


### PR DESCRIPTION
## Problem

When a release is published as a prerelease, it gets tagged as `edge` on npm. Later, when the release is promoted to a full release in GitHub, the npm `latest` tag doesn't update because the workflow only triggered on `published`.

## Solution

- Added `released` to the release workflow trigger types
- New lightweight `promote` job that only runs `npm dist-tag add latest` — no install, no lint, no tests, no re-publish
- Only fires on the `released` event (when a prerelease is promoted to full release)
- Existing `deploy` job is now explicitly gated to `published` events only (no behavior change)
- Uses `TAG_NAME` env var instead of direct interpolation to prevent script injection

## Flow

1. Publish as prerelease → full pipeline runs, publishes with `edge` tag (unchanged)
2. Promote release → uncheck prerelease → `promote` job runs, points `latest` to that version (~15s)

The `dist-tag add` command is idempotent, so if both `published` and `released` fire on a fresh non-prerelease publish, the redundant promote is harmless.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adjusts when npm dist-tags are updated; risk is limited to potential mis-tagging of `latest` if the release tag/version is incorrect.
> 
> **Overview**
> Extends the GitHub Actions release workflow to also trigger on `released` events (in addition to `published`).
> 
> Adds a lightweight `promote` job that, on release promotion, runs `npm dist-tag add ... latest` for the released version so `latest` is updated without re-running the full publish pipeline; the existing `deploy` job is now explicitly gated to only run on `published`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63e28ac7c58a2e3e4b96c9cb2c72ced0718589f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->